### PR TITLE
Modified path validation and XML extraction.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /deps
 erl_crash.dump
 *.ez
+.DS_Store
+/*/.DS_Store

--- a/lib/xlsxir.ex
+++ b/lib/xlsxir.ex
@@ -8,7 +8,7 @@ defmodule Xlsxir do
 
   @doc """
   Provides a list of row value lists or a map of cell/value pairs from a Microsoft Excel workbook
-  given the path to a file of extension type `.xlsx`, the index of the worksheet in which the information 
+  given the path to a file of extension type `.xlsx`, the index of the worksheet in which the information
   is requested, and an option.
 
   Cells containing formulas return either a `string`, `integer` or `float` of the resulting value. Cells containing Excel date format return
@@ -21,7 +21,7 @@ defmodule Xlsxir do
 
   ## Options
 
-  - `:rows` - a list of row value lists (default) - i.e. [[row_1_values], [row_2_values], ...] 
+  - `:rows` - a list of row value lists (default) - i.e. [[row_1_values], [row_2_values], ...]
   - `:cells` - a map of cell/value pairs - i.e. %{ A1: value_of_cell, B1: value_of_cell, ...}
 
   ## Example
@@ -39,12 +39,10 @@ defmodule Xlsxir do
           %{ A1: "string one", B1: "string two", C1: 10, D1: 20, E1: {2016,1,1}}
   """
   def extract(path, index, option \\ :rows) do
-    strings = path
-              |> Unzip.validate_path
-              |> Parse.shared_strings
+    {:ok, file} = Unzip.validate_path(path)
+    strings = Parse.shared_strings(file)
 
-    path
-    |> Unzip.validate_path
+    file
     |> Parse.worksheet(index)
     |> Format.prepare_output(strings, option)
   end

--- a/lib/xlsxir/format.ex
+++ b/lib/xlsxir/format.ex
@@ -1,8 +1,8 @@
 defmodule Xlsxir.Format do
-  
+
   @moduledoc """
   Receives parsed excel worksheet data, formats the cell values and returns the data in either a
-  list or a map depending on the option chosen. 
+  list or a map depending on the option chosen.
   """
 
   @doc """
@@ -15,11 +15,11 @@ defmodule Xlsxir.Format do
       :cells -> cell_map(worksheet, shared_strings)
       _      -> raise ArgumentError, message: "Invalid option."
     end
-  end 
+  end
 
   @doc """
-  Formats parsed excel worksheet into a list of lists containing cell values by row.  
-  
+  Formats parsed excel worksheet into a list of lists containing cell values by row.
+
   ## Parameters
 
   - `sheet` - map of xml worksheet data from Excel file that was parsed via Xlsxir.Parse.worksheet/2
@@ -30,29 +30,29 @@ defmodule Xlsxir.Format do
   """
   def row_list(sheet, strings) do
     sheet
-    |> Enum.map(fn row -> 
+    |> Enum.map(fn row ->
         Enum.map(row, fn {_k, v} -> format_cell_value(v, strings) end)
       end)
   end
 
   @doc """
   Formats parsed excel worksheet into a map of cell/value pairs.
-     
+
   ## Parameters
 
   - `sheet` - map of xml worksheet data from Excel file that was parsed via `Xlsxir.Parse.worksheet/2`
   - `strings` - list of sharedStrings.xml data from Excel file that was parsed via `Xlsxir.Parse.shared_strings/1`
 
   ## Example
-     
+
       %{ A1: value_of_cell, B1: value_of_cell, ...}
   """
   def cell_map(sheet, strings) do
     sheet
-    |> Enum.map(fn row -> 
-        Enum.map(row, fn{k, v} -> 
-          {k, format_cell_value(v, strings)} 
-        end) 
+    |> Enum.map(fn row ->
+        Enum.map(row, fn{k, v} ->
+          {k, format_cell_value(v, strings)}
+        end)
       end)
     |> List.flatten
     |> Enum.reduce(%{}, &(Enum.into [&1], &2))
@@ -78,8 +78,9 @@ defmodule Xlsxir.Format do
       ['s', i]     -> Enum.at(strings, List.to_integer(i))                    # Excel type string
       [nil, n]     -> convert_char_number(n)                                  # Excel type number
       ['1', d]     -> Xlsxir.ConvertDate.from_excel(d)                        # Excel type date
+      ['2', d]     -> Xlsxir.ConvertDate.from_excel(d)                        # Excel type date
       ['str', f_s] -> List.to_string(f_s)                                     # Excel type Formula w/ string
-      _            -> raise "Invalid attribute #{list}. Unable to process"    # invalid Excel type
+      _            -> raise "Unmapped attribute #{Enum.at(list, 0)}. Unable to process"   # Unmapped Excel type
     end
   end
 
@@ -101,7 +102,7 @@ defmodule Xlsxir.Format do
 
 #   # generate reference list for all cells
 #   defp cell_reference_list do
-#     Stream.flat_map(1..1048576, fn n -> 
+#     Stream.flat_map(1..1048576, fn n ->
 #       Stream.map(0..16384, fn i -> String.to_atom(col_letter(i) <> Integer.to_string(n)) end)
 #     end)
 #   end
@@ -131,8 +132,3 @@ defmodule Xlsxir.Format do
 #   end
 
 end
-
-
-
-
-

--- a/lib/xlsxir/parse.ex
+++ b/lib/xlsxir/parse.ex
@@ -21,10 +21,10 @@ defmodule Xlsxir.Parse do
     - cell 'D1' -> formula of `=4*5`
     - cell 'E1' -> date of 1/1/2016 or Excel date serial of 42370
 
-          iex> Xlsxir.Parse.shared_strings({:ok, "./test/test_data/test.xlsx"})
+          iex> Xlsxir.Parse.shared_strings("./test/test_data/test.xlsx")
           ["string one", "string two"]
   """
-  def shared_strings({:ok, path}) do
+  def shared_strings(path) do
     {:ok, strings} = extract_xml(path, 'xl/sharedStrings.xml')
     strings
     |> xpath(~x"//t/text()"sl)
@@ -49,14 +49,14 @@ defmodule Xlsxir.Parse do
     - cell 'D1' -> formula of `=4*5`
     - cell 'E1' -> date of 1/1/2016 or Excel date serial of 42370
 
-          iex> Xlsxir.Parse.worksheet({:ok, "./test/test_data/test.xlsx"}, 0)
+          iex> Xlsxir.Parse.worksheet("./test/test_data/test.xlsx", 0)
           [[A1: ['s', '0'], B1: ['s', '1'], C1: [nil, '10'], D1: [nil, '20'], E1: ['1', '42370']]]
   """
-  def worksheet({:ok, path}, index) do
+  def worksheet(path, index) do
     {:ok, sheet} = extract_xml(path, 'xl/worksheets/sheet#{index + 1}.xml')
 
     sheet
-    |> xpath(~x"//worksheet/sheetData/row/c"l) 
+    |> xpath(~x"//worksheet/sheetData/row/c"l)
     |> Stream.map(&process_column/1)
     |> Enum.chunk_by(fn cell -> Keyword.keys([cell])
                                 |> List.first
@@ -80,7 +80,7 @@ defmodule Xlsxir.Parse do
                end
 
     attribute = case List.last(xml_attr) do
-                  {:xmlAttribute, _,_,_,_,_,_,_,attr,_} when n == 2 -> attr 
+                  {:xmlAttribute, _,_,_,_,_,_,_,attr,_} when n == 2 -> attr
                   _                                                 -> nil
                 end
 
@@ -91,6 +91,7 @@ defmodule Xlsxir.Parse do
     case xml_elem do
       [{:xmlElement,_,_,_,{_,_,[{_,_},{_,_},{_,_}]},[_,_,_,_],_,_,[{_,_,_,_,val,_}],_,_,_}] -> val
       [_,{:xmlElement,_,_,_,_,_,_,_,[{_,_,_,_,funct_val,_}],_,_,_}] -> funct_val
+      [] -> nil
     end
   end
 
@@ -99,5 +100,5 @@ defmodule Xlsxir.Parse do
     |> Regex.scan(cell)
     |> List.to_string
   end
-  
+
 end

--- a/lib/xlsxir/unzip.ex
+++ b/lib/xlsxir/unzip.ex
@@ -2,11 +2,11 @@ defmodule Xlsxir.Unzip do
 
   @moduledoc """
   Provides validation of accepted file extension types for file path and extracts requested inner files
-  from a `.zip` file type. 
+  from a `.zip` file type.
   """
 
   @doc """
-  Validates given path is of extension type `.xlsx` and returns a tuple. 
+  Validates given path is of extension type `.xlsx` and returns a tuple.
 
   ## Parameters
 
@@ -16,21 +16,18 @@ defmodule Xlsxir.Unzip do
 
       iex> path = "Good_Example.xlsx"
       iex> Xlsxir.Unzip.validate_path(path)
-      {:ok, "Good_Example.xlsx"}
+      {:ok, 'Good_Example.xlsx'}
 
       iex> path = "bad_path.xml"
       iex> Xlsxir.Unzip.validate_path(path)
       {:error, "Invalid path. Currently only .xlsx file types are supported."}
   """
   def validate_path(path) do
-    path
-    |> String.downcase
-    |> String.split(".", trim: true)
-    |> List.last
-    |> case do
-      "xlsx" -> {:ok, path}
-      _      -> {:error, "Invalid path. Currently only .xlsx file types are supported."}
-    end  
+    path = to_string path
+    cond do
+      Regex.match?(~r/\.xlsx$/, path) -> {:ok, to_char_list path}
+      true -> {:error, "Invalid path. Currently only .xlsx file types are supported."}
+    end
   end
 
   @doc """
@@ -51,24 +48,16 @@ defmodule Xlsxir.Unzip do
         iex> Xlsxir.Unzip.extract_xml(path, inner_path)
         {:ok, "test_successful"}
   """
+
   def extract_xml(path, inner_path) do
     path
     |> to_char_list
-    |> :zip.zip_open([:memory])
+    |> :zip.extract([:memory, {:file_filter, fn(file) -> elem(file, 1) == inner_path end}])
     |> case do
-      {:error, cause}      -> {:error, cause}
-      {:ok, zip_directory} ->
-        inner_path
-        |> :zip.zip_get(zip_directory)
-        |> case do
-          {:error, cause}          -> {:error, cause}
-          {:ok, {_, file_content}} ->
-            case :zip.zip_close(zip_directory) do
-              {:error, cause} -> {:error, cause}
-              :ok             -> {:ok, file_content}
-            end
-        end
-    end
+        {:ok, [{_, file_content}]} -> {:ok, file_content}
+        {:ok, []}                  -> {:error, :file_not_found}
+        {:error, cause}            -> {:error, cause}
+       end
   end
 
 end

--- a/test/parse_test.exs
+++ b/test/parse_test.exs
@@ -5,16 +5,16 @@ defmodule ParseTest do
   import Xlsxir.Parse
 
   test "second worksheet is parsed with index argument of 1" do
-    assert worksheet({:ok, "./test/test_data/test.xlsx"}, 1) == [[A1: [nil, '1'], B1: [nil, '2']], [A2: [nil, '3'], B2: [nil, '4']]]
+    assert worksheet("./test/test_data/test.xlsx", 1) == [[A1: [nil, '1'], B1: [nil, '2']], [A2: [nil, '3'], B2: [nil, '4']]]
   end
 
   test "able to parse maximum number of columns" do
-    sheet3 = worksheet({:ok, "./test/test_data/test.xlsx"}, 2)
+    sheet3 = worksheet("./test/test_data/test.xlsx", 2)
     assert List.first(sheet3)[:XFD1] == [nil, '16384']
   end
 
   test "able to parse maximum number of rows" do
-    sheet4 = worksheet({:ok, "./test/test_data/test.xlsx"}, 3)
+    sheet4 = worksheet("./test/test_data/test.xlsx", 3)
     assert List.last(sheet4)[:A1048576] == [nil, '1048576']
   end
 

--- a/test/unzip_test.exs
+++ b/test/unzip_test.exs
@@ -10,7 +10,7 @@ defmodule UnzipTest do
   @incorrect_inner_path 'bad_inner_path.txt'
 
   test "path has the correct extension" do
-    assert validate_path("correct_path.xlsx") == {:ok, "correct_path.xlsx"}
+    assert validate_path("correct_path.xlsx") == {:ok, 'correct_path.xlsx'}
   end
 
   test "path has incorrect extension" do

--- a/test/xlsxir_test.exs
+++ b/test/xlsxir_test.exs
@@ -1,8 +1,4 @@
 defmodule XlsxirTest do
   use ExUnit.Case
   doctest Xlsxir
-
-  test "the truth" do
-    assert 1 + 1 == 2
-  end
 end


### PR DESCRIPTION
I changed the `Xlsxir.extract/3` to only validate the path once.

I also changed the path arguments to a string (or char_list) for `Parse.shared_strings/1` and `Parse.worksheet/2` instead of `{:ok, path}`.

I also changed the `Unzip.extract_xml/2` function a little bit.