### PR TITLE
sort attribute keys so they will always pattern match

### DIFF
--- a/lib/xlsxir/parse_worksheet.ex
+++ b/lib/xlsxir/parse_worksheet.ex
@@ -40,11 +40,11 @@ defmodule Xlsxir.ParseWorksheet do
           end
         end)
 
-    {cell_ref, num_style, data_type} = case Keyword.keys(a) do
+    {cell_ref, num_style, data_type} = case Keyword.keys(a) |> Enum.sort do
                                          [:r]         -> {a[:r],   nil,   nil}
-                                         [:s, :r]     -> {a[:r], a[:s],   nil}
-                                         [:t, :r]     -> {a[:r],   nil, a[:t]}
-                                         [:t, :s, :r] -> {a[:r], a[:s], a[:t]}
+                                         [:r, :s]     -> {a[:r], a[:s],   nil}
+                                         [:r, :t]     -> {a[:r],   nil, a[:t]}
+                                         [:r, :s, :t] -> {a[:r], a[:s], a[:t]}
                                          _            -> raise "Invalid attributes: #{a}"
                                        end
     %{state | cell_ref: cell_ref, num_style: num_style, data_type: data_type}


### PR DESCRIPTION
Sometimes attribute keys exist, but not in the expected order, e.g.:

```zsh
** (ArgumentError) cannot convert the given list to a string.

To be converted to a string, a list must contain only:

  * strings
  * integers representing Unicode codepoints
  * or a list containing one of these three elements

Please check the given list or call inspect/1 to get the list representation, got:

[s: nil, t: 's', r: 'A1']

    (elixir) lib/list.ex:624: List.to_string/1
    (xlsxir) lib/xlsxir/parse_worksheet.ex:48: Xlsxir.ParseWorksheet.sax_event_handler/2
```