### PR TITLE
fix the case sheet is empty

### DIFF
--- a/lib/xlsxir.ex
+++ b/lib/xlsxir.ex
@@ -76,7 +76,7 @@ defmodule Xlsxir do
   """
   def peek(path, index, rows) do
     case Unzip.validate_path_and_index(path, index) do
-      {:ok, file}      -> 
+      {:ok, file}      ->
         case extract_xml(file, index) do
           {:ok, file_paths} -> do_peek_extract(file_paths, index, false, rows)
           {:error, reason}  -> {:error, reason}
@@ -402,10 +402,10 @@ defmodule Xlsxir do
   def get_row(table_id, row), do: do_get_row(row, table_id)
 
   defp do_get_row(row, table_id \\ :worksheet) do
-    [[row]] = :ets.match(table_id, {row, :"$1"})
-
-    row
-    |> Enum.map(fn [_ref, val] -> val end)
+    case :ets.match(table_id, {row, :"$1"}) do
+      [[row]] -> row |> Enum.map(fn [_ref, val] -> val end)
+      [] -> []
+    end
   end
 
   @doc """


### PR DESCRIPTION
Stacktrace:

```
** (CaseClauseError) no case clause matching: []
             lib/xlsxir.ex:405: Xlsxir.do_get_row/2
    (elixir) lib/stream.ex:495: anonymous fn/4 in Stream.map/2
    (elixir) lib/range.ex:96: Enumerable.Range.reduce/5
    (elixir) lib/stream.ex:1403: Enumerable.Stream.do_each/4
    (elixir) lib/enum.ex:1767: Enum.reverse/2
    (elixir) lib/enum.ex:2528: Enum.to_list/1
```