### PR TITLE
Replace Enum.into(row ...  with row ++

### DIFF
--- a/lib/xlsxir/parse_worksheet.ex
+++ b/lib/xlsxir/parse_worksheet.ex
@@ -66,7 +66,7 @@ defmodule Xlsxir.ParseWorksheet do
 
   def sax_event_handler({:endElement,_,'c',_}, %__MODULE__{row: row} = state, excel) do
     cell_value = format_cell_value(excel, [state.data_type, state.num_style, state.value])
-    %{state | row: Enum.into(row, [[to_string(state.cell_ref), cell_value]]), cell_ref: "", data_type: "", num_style: "", value: ""}
+    %{state | row: row ++ [[to_string(state.cell_ref), cell_value]]), cell_ref: "", data_type: "", num_style: "", value: ""}
   end
 
   def sax_event_handler({:endElement,_,'row',_}, %__MODULE__{tid: tid, max_rows: max_rows} = state, _excel) do


### PR DESCRIPTION
We can avoid this warning:


> warning: the Collectable protocol is deprecated for non-empty lists. The behaviour of things like Enum.into/2 or "for" comprehensions with an :into option is incorrect when collecting into non-empty lists. If you're collecting into a non-empty keyword list, consider using Keyword.merge/2 instead. If you're collecting into a non-empty list, consider concatenating the two lists with the ++ operator.
