### PR TITLE
Fix filling empty cells

### DIFF
--- a/lib/xlsxir/parse_worksheet.ex
+++ b/lib/xlsxir/parse_worksheet.ex
@@ -143,7 +143,7 @@ defmodule Xlsxir.ParseWorksheet do
 
       empty_cells =
         cond do
-          is_nil(previous) && String.first(ref) != "A" ->
+          is_nil(previous) && !Regex.match?(~r/^A\d/, ref) ->
             fill_empty_cells("A#{line}", ref, line, [])
 
           !is_nil(previous) && !is_next_col(ref, previous) ->


### PR DESCRIPTION
There are situations where the first non-empty cell on a row is like `AA1`, which has not been handled previously. This PR fixes that.

There is currently no test case for this. Can I modify the test data to add a test case for this PR?