### PR TITLE
Add `sheet_names` and extend multi_extract to extract sheet by name

### DIFF
--- a/lib/xlsxir.ex
+++ b/lib/xlsxir.ex
@@ -91,6 +91,41 @@ defmodule Xlsxir do
   end
 
   @doc """
+  Returns the list of worksheet names contained in the specified `.xlsx` file,
+  in workbook order.
+
+  ## Parameters
+  - `path` - file path of a `.xlsx` file type in `string` format
+
+  ## Options
+  - `:extract_to` - Specify how the `.xlsx` content will be extracted before being parsed.
+    `:memory` will extract files to memory, and `:file` to files in the file system
+  - `:extract_base_dir` - when extracting to file, files will be extracted
+     in a sub directory in the `:extract_base_dir` directory. Defaults to
+     `Application.get_env(:xlsxir, :extract_base_dir)` or "temp"
+
+  ## Example
+  List all worksheet names in an example file named `test.xlsx` located in `./test/test_data`:
+
+        iex> {:ok, names} = Xlsxir.sheet_names("./test/test_data/test.xlsx")
+        iex> length(names)
+        11
+        iex> hd(names)
+        "Sheet1"
+  """
+  def sheet_names(path, options \\ []) do
+    case XlsxFile.initialize(path, options) do
+      {:error, _} = error ->
+        error
+
+      xlsx_file ->
+        names = XlsxFile.sheet_names(xlsx_file)
+        XlsxFile.clean(xlsx_file)
+        {:ok, names}
+    end
+  end
+
+  @doc """
   Stream worksheet rows contained in the specified `.xlsx` file.
 
   Cells containing formulas in the worksheet are extracted as either a `string`, `integer` or `float` depending on the resulting value of the cell.
@@ -174,7 +209,7 @@ defmodule Xlsxir do
 
   ## Parameters
   - `path` - file path of a `.xlsx` file type in `string` format
-  - `index` - index of worksheet from within the Excel workbook to be parsed (zero-based index)
+  - `index` - index of worksheet from within the Excel workbook to be parsed (zero-based index), or a `string` worksheet name.
   - `timer` - boolean flag that tracts extraction process time and returns it when set to `true`. Defalut value is `false`.
 
   ## Options
@@ -190,6 +225,15 @@ defmodule Xlsxir do
   Extract first worksheet in an example file named `test.xlsx` located in `./test/test_data`:
 
         iex> {:ok, tid} = Xlsxir.multi_extract("./test/test_data/test.xlsx", 0)
+        iex> Enum.member?(:ets.all, tid)
+        true
+        iex> Xlsxir.close(tid)
+        :ok
+
+  ## Example
+  Extract worksheet by name in an example file named `test.xlsx` located in `./test/test_data`:
+
+        iex> {:ok, tid} = Xlsxir.multi_extract("./test/test_data/test.xlsx", "Sheet1")
         iex> Enum.member?(:ets.all, tid)
         true
         iex> Xlsxir.close(tid)
@@ -222,6 +266,9 @@ defmodule Xlsxir do
 
         iex> Xlsxir.multi_extract("./test/test_data/test.xlsx", 100)
         {:error, "Invalid worksheet index."}
+
+        iex> Xlsxir.multi_extract("./test/test_data/test.xlsx", "NonExistent")
+        {:error, "Worksheet \\\"NonExistent\\\" not found."}
   """
   def multi_extract(path, index \\ nil, timer \\ false, _excel \\ nil, options \\ [])
 
@@ -239,6 +286,10 @@ defmodule Xlsxir do
 
   def multi_extract(path, index, timer, _excel, options) when is_integer(index) do
     extract(path, index, timer, options)
+  end
+
+  def multi_extract(path, name, timer, _excel, options) when is_binary(name) do
+    extract(path, name, timer, options)
   end
 
   @doc """

--- a/lib/xlsxir/parse_workbook.ex
+++ b/lib/xlsxir/parse_workbook.ex
@@ -37,9 +37,19 @@ defmodule Xlsxir.ParseWorkbook do
   end
 
   def sax_event_handler(:endDocument, %__MODULE__{tid: tid} = state) do
-    Enum.map(state.sheets, fn %{sheet_id: sheet_id, name: name} ->
+    # Reverse state.sheets so we have the correct order
+    ordered_sheets = Enum.reverse(state.sheets)
+
+    Enum.each(ordered_sheets, fn %{sheet_id: sheet_id, name: name} ->
       :ets.insert(tid, {sheet_id, name})
     end)
+
+    Enum.each(ordered_sheets, fn %{name: name, rid: rid} ->
+      :ets.insert(tid, {{:sheet_name, name}, rid})
+    end)
+
+    names = Enum.map(ordered_sheets, fn %{name: name} -> name end)
+    :ets.insert(tid, {:sheet_names, names})
 
     state
   end

--- a/lib/xlsxir/xlsx_file.ex
+++ b/lib/xlsxir/xlsx_file.ex
@@ -81,6 +81,13 @@ defmodule Xlsxir.XlsxFile do
     end
   end
 
+  def parse_to_ets(%__MODULE__{} = xlsx_file, worksheet_name, timer)
+      when is_binary(worksheet_name) do
+    with {:ok, worksheet_xml_file} <- get_worksheet(xlsx_file, worksheet_name) do
+      parse_to_ets(xlsx_file, worksheet_xml_file, timer)
+    end
+  end
+
   def parse_to_ets(%__MODULE__{} = xlsx_file, %XmlFile{} = worksheet_xml_file, true) do
     start_timestamp = :erlang.timestamp()
     {:ok, tid} = parse_to_ets(xlsx_file, worksheet_xml_file, false)
@@ -146,6 +153,18 @@ defmodule Xlsxir.XlsxFile do
     # Sort worksheets by name (i.e. index)
     |> Enum.sort(&(&1.name <= &2.name))
     |> Enum.map(&parse_to_ets(xlsx_file, &1, timer))
+  end
+
+  @doc """
+  Returns the ordered list of worksheet names from the workbook.
+  """
+  def sheet_names(%__MODULE__{workbook: nil}), do: []
+
+  def sheet_names(%__MODULE__{} = xlsx_file) do
+    case :ets.lookup(xlsx_file.workbook, :sheet_names) do
+      [{:sheet_names, names}] -> names
+      [] -> []
+    end
   end
 
   @doc """
@@ -301,6 +320,24 @@ defmodule Xlsxir.XlsxFile do
   end
 
   defp parse_shared_strings_to_ets({:error, _} = error), do: error
+
+  defp get_worksheet(%__MODULE__{} = xlsx_file, name) when is_binary(name) do
+    case :ets.match(xlsx_file.workbook, {{:sheet_name, name}, :"$1"}) do
+      [[rid]] ->
+        xml_file =
+          Enum.find(xlsx_file.worksheet_xml_files, fn xml_file ->
+            xml_file.name == "sheet#{rid}.xml"
+          end)
+
+        case xml_file do
+          nil -> {:error, "Worksheet \"#{name}\" not found."}
+          %XmlFile{} -> {:ok, xml_file}
+        end
+
+      [] ->
+        {:error, "Worksheet \"#{name}\" not found."}
+    end
+  end
 
   defp get_worksheet(%__MODULE__{} = xlsx_file, index) do
     xml_file =

--- a/test/stream_test.exs
+++ b/test/stream_test.exs
@@ -21,4 +21,10 @@ defmodule StreamTest do
     # third run because reasons
     assert {:ok, _} = Task.yield( Task.async( fn() -> s |> Stream.run() end ), 2000)
   end
+
+  test "stream by sheet name" do
+    s = stream_list(path(), "Sheet9")
+    assert %Stream{} = s
+    assert 51 == s |> Enum.map(&(&1)) |> length
+  end
 end

--- a/test/xlsxir_test.exs
+++ b/test/xlsxir_test.exs
@@ -157,4 +157,45 @@ defmodule XlsxirTest do
     assert map["B2"] == "pre 2008"
     assert map["B3"] == "https://msdn.microsoft.com/en-us/library/office/gg278314.aspx"
   end
+
+  test "sheet_names returns all worksheet names" do
+    {:ok, names} = Xlsxir.sheet_names(path())
+    assert length(names) == 11
+    assert hd(names) == "Sheet1"
+    assert List.last(names) == "Sheet11"
+  end
+
+  test "sheet_names returns error for invalid file" do
+    assert {:error, _} = Xlsxir.sheet_names("./test/test_data/test.invalidfile")
+  end
+
+  test "extract by sheet name" do
+    {:ok, pid} = extract(path(), "Sheet1")
+    assert get_list(pid) == [["string one", "string two", 10, 20, {2016, 1, 1}]]
+    close(pid)
+  end
+
+  test "extract second worksheet by name" do
+    {:ok, pid} = extract(path(), "Sheet2")
+    assert get_list(pid) == [[1, 2], [3, 4]]
+    close(pid)
+  end
+
+  test "extract by invalid sheet name returns error" do
+    assert {:error, "Worksheet \"NonExistent\" not found."} =
+             extract(path(), "NonExistent")
+  end
+
+  test "multi_extract by sheet name" do
+    {:ok, tid} = multi_extract(path(), "Sheet1")
+    assert get_list(tid) == [["string one", "string two", 10, 20, {2016, 1, 1}]]
+    close(tid)
+  end
+
+  test "peek by sheet name" do
+    {:ok, pid} = peek(path(), "Sheet9", 10)
+    assert get_cell(pid, "G10") == 8437
+    assert get_info(pid, :rows) == 10
+    close(pid)
+  end
 end


### PR DESCRIPTION
This PR adds a new top-level function called `sheet_names` which returns the names of the sheets in the given xlsx file. It also adds support for extracting specific sheets from a xlsx file by passing in the name of the sheet to `multi_extract`.

To support this functionality, a couple of new entries are added to the ets table, to allow looking up all the sheet names and mapping a sheet name to the relationship id.

Much of the functionality to support looking up specific sheets by their name was already present in the code, it just needed to be exposed.